### PR TITLE
Fix tests not running all cases

### DIFF
--- a/src/application/use-cases/create-gym.spec.ts
+++ b/src/application/use-cases/create-gym.spec.ts
@@ -13,7 +13,7 @@ describe('CreateGym use case', () => {
     sut = new CreateGymUseCase()
   })
 
-  it.only('should create a gym', async () => {
+  it('should create a gym', async () => {
     const result = await sut.execute({
       title: 'Academia TypeScript Gym',
       latitude: -27.0747279,

--- a/tests/authenticate.e2e-spec.ts
+++ b/tests/authenticate.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('Authenticate (e2e)', () => {
     await fastify.close()
   })
 
-  it.only('should be able to authenticate an user', async () => {
+  it('should be able to authenticate an user', async () => {
     await request(fastify.server).post(Routes.USERS).send({
       name: 'John Doe',
       email: 'johm@doe.com',


### PR DESCRIPTION
## Summary
- remove stray `.only` in unit test suite
- remove stray `.only` in e2e tests

## Testing
- `npm test` *(fails: 403 Forbidden for package registry)*

------
https://chatgpt.com/codex/tasks/task_e_6840889f0d3c8329a8932cca3867e92b