### PR TITLE
Update dayjs helper to use utc plugin

### DIFF
--- a/src/application/entities/services/date-helper.spec.ts
+++ b/src/application/entities/services/date-helper.spec.ts
@@ -27,13 +27,13 @@ describe('DateHelper test suite', () => {
   it('should return start of date', () => {
     const date = new Date(2023, 0, 1, 13, 40, 0)
     const startOfDay = dateHelper.startOfTheDay(date)
-    expect(startOfDay).toEqual(new Date('2023-01-01T03:00:00.000Z'))
+    expect(startOfDay).toEqual(new Date('2023-01-01T00:00:00.000Z'))
   })
 
   it('should return end of date', () => {
     const date = new Date(2023, 0, 1, 13, 40, 0)
     const startOfDay = dateHelper.endOfTheDay(date)
-    expect(startOfDay).toEqual(new Date('2023-01-02T02:59:59.999Z'))
+    expect(startOfDay).toEqual(new Date('2023-01-01T23:59:59.999Z'))
   })
 
   it('should return distance in minutes', () => {

--- a/src/application/entities/services/date-helper.ts
+++ b/src/application/entities/services/date-helper.ts
@@ -1,4 +1,7 @@
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
 
 export class DateHelper {
   public distanceInMinutesFromDate(aDate: Date): number {
@@ -6,8 +9,8 @@ export class DateHelper {
   }
 
   public isOnSameDate(initialDate: Date, targetDate: Date): boolean {
-    const startOfTheDay = dayjs(initialDate).startOf('date')
-    const endOfTheDay = dayjs(initialDate).endOf('date')
+    const startOfTheDay = dayjs(initialDate).utc().startOf('day')
+    const endOfTheDay = dayjs(initialDate).utc().endOf('day')
     const targetDateDayJs = dayjs(targetDate)
     return (
       targetDateDayJs.isAfter(startOfTheDay) &&
@@ -16,10 +19,10 @@ export class DateHelper {
   }
 
   public startOfTheDay(aDate: Date): Date {
-    return dayjs(aDate).startOf('date').toDate()
+    return dayjs(aDate).utc().startOf('day').toDate()
   }
 
   public endOfTheDay(aDate: Date): Date {
-    return dayjs(aDate).endOf('date').toDate()
+    return dayjs(aDate).utc().endOf('day').toDate()
   }
 }


### PR DESCRIPTION
## Summary
- use `dayjs` `utc` plugin in `DateHelper`
- update helper unit tests for UTC output

## Testing
- `npm install`
- `npm test` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9eda3548329b6f82d2a79b50748